### PR TITLE
兼容数据驱动，并优化用例错误日志

### DIFF
--- a/pytest/.coveragerc
+++ b/pytest/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = testdata/*

--- a/pytest/pdm.lock
+++ b/pytest/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:a95bd5d1239d4e9fe9e8928bc4ba7b6e70ad5f0aa64305a33cb993a3e6f6f162"
+content_hash = "sha256:2aa57a8caa3f18923676cb60227545088997f7df55afbc2d3851a0c0b85d4b30"
 
 [[package]]
 name = "colorama"
@@ -364,7 +364,7 @@ files = [
 
 [[package]]
 name = "testsolar-testtool-sdk"
-version = "0.1.7"
+version = "0.1.8"
 requires_python = ">=3.8"
 summary = "TestSolar测试工具SDK"
 groups = ["default"]
@@ -373,8 +373,8 @@ dependencies = [
     "portalocker>=2.8.2",
 ]
 files = [
-    {file = "testsolar-testtool-sdk-0.1.7.tar.gz", hash = "sha256:15857f0ea6dac4be8c8b593c943d209247d8e3c4de95381c3c4218a16fbff5c1"},
-    {file = "testsolar_testtool_sdk-0.1.7-py3-none-any.whl", hash = "sha256:c9f1d00c47a4e8a0f204d7b7660b30ffc46fc398f577b0611c8f62bbdee54196"},
+    {file = "testsolar-testtool-sdk-0.1.8.tar.gz", hash = "sha256:e2a04673e33d2eb17272d5b527477faf2d66267df9e0d3da4d3195fd27d891d0"},
+    {file = "testsolar_testtool_sdk-0.1.8-py3-none-any.whl", hash = "sha256:f21fec3ccb31b509eb37e0aecd309a20bfd02479407a1e8cd7550c3429073f5c"},
 ]
 
 [[package]]

--- a/pytest/pyproject.toml
+++ b/pytest/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 dependencies = [
     "pytest>=8.1.1",
     "pytest-timeout>=2.3.1",
-    "testsolar-testtool-sdk>=0.1.7",
+    "testsolar-testtool-sdk>=0.1.8",
 ]
 requires-python = ">=3.8"
 readme = "README.md"

--- a/pytest/src/converter.py
+++ b/pytest/src/converter.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 
 def selector_to_pytest(test_selector: str) -> str:

--- a/pytest/src/converter.py
+++ b/pytest/src/converter.py
@@ -21,28 +21,33 @@ def selector_to_pytest(test_selector: str) -> str:
     else:
         if testcase.startswith("name="):
             testcase = testcase[5:]
-    if "/[" in testcase:
-        testcase = encode_datadrive(testcase.replace("/[", "["))
+
+    testcase = encode_datadrive(testcase)
     return path + "::" + testcase.replace("/", "::")
 
 
-def encode_datadrive(name):
-    if sys.version_info[0] >= 3:
+def encode_datadrive(name: str) -> str:
+    if "/[" in name:
         name = name.encode("unicode_escape").decode()
-    else:
-        if not isinstance(name, bytes):
-            name = name.encode("utf-8")
-        name = name.encode("string-escape")
+        name = name.replace("/[", "[")
     return name
 
 
-def decode_datadrive(name):
-    if sys.version_info[0] >= 3:
+def decode_datadrive(name: str) -> str:
+    """
+    将数据驱动转换为utf8字符，对用户来说可读性更好。
+
+    原因：pytest by default escapes any non-ascii characters used in unicode strings for the parametrization because it has several downsides.
+
+    https://docs.pytest.org/en/7.0.x/how-to/parametrize.html
+
+    test_include[\u4e2d\u6587-\u4e2d\u6587\u6c49\u5b57] -> test_include[中文-中文汉字]
+    """
+    if name.endswith(']'):
+        name = name.replace('[', "/[")
         if re.search(r"\\u\w{4}", name):
             name = name.encode().decode("unicode_escape")
-    else:
-        name = name.decode("string-escape")
-        name = name.decode("string-escape")  # need decode twice
+
     return name
 
 
@@ -55,8 +60,6 @@ def normalize_testcase_name(name: str) -> str:
         name.replace("::", "?", 1).replace(  # 第一个分割符是文件，因此替换为?
             "::", "/"
         )  # 后续的分割符是测试用例名称，替换为/
-    )  # 数据驱动值前面加上/
-    if "[" in name:
-        name = decode_datadrive(name)
-
+    )
+    name = decode_datadrive(name)
     return name

--- a/pytest/src/parser.py
+++ b/pytest/src/parser.py
@@ -1,5 +1,6 @@
 import json
 from typing import Dict
+from pytest import Item
 
 
 # 支持 @pytest.mark.attributes({"key":"value"}) 这种用法
@@ -9,10 +10,10 @@ from typing import Dict
 # - tag
 # - owner
 # - extra_attributes
-def parse_case_attributes(item) -> Dict[str, str]:
+def parse_case_attributes(item: Item) -> Dict[str, str]:
     """parse testcase attributes"""
     attributes: Dict[str, str] = {
-        "description": (str(item.function.__doc__) or "").strip()
+        "description": (str(item.function.__doc__) or "").strip()  # type: ignore
     }
     if not item.own_markers:
         return attributes

--- a/pytest/testdata/data_drive_zh_cn.py
+++ b/pytest/testdata/data_drive_zh_cn.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.parametrize("test_input,expected", [("#?", "#?^$%!/"), ("中文", "中文汉字"), ("파일을 찾을 수 없습니다", "ファイルが見つかりません")])
+def test_include(test_input: str, expected: str):
+    """
+    测试包含UTF-8字符的数据驱动用例
+    """
+    assert test_input in expected

--- a/pytest/testdata/normal_case.py
+++ b/pytest/testdata/normal_case.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 
@@ -23,8 +25,6 @@ def test_success(print_extra_msg):
     assert inc(3) == 4
 
 
-@pytest.mark.low
-@pytest.mark.owner("bar")
 def test_failed():
     print("this is assert output")
     assert inc(3) == 6
@@ -33,6 +33,6 @@ def test_failed():
 @pytest.mark.low
 @pytest.mark.owner("bar")
 def test_raise_error():
-    print("this is assert output")
+    print("this is raise output", file=sys.stderr)
     assert inc(3) == 4
     raise RuntimeError("this is raise runtime error")

--- a/pytest/tests/test_collector.py
+++ b/pytest/tests/test_collector.py
@@ -77,6 +77,25 @@ class CollectorTest(unittest.TestCase):
             "not_exist.py does not exist, SKIP it", re.LoadErrors[0].message
         )
 
+    def test_collect_testcases_with_utf8_chars(self):
+        entry = EntryParam(
+            TaskId="aa",
+            ProjectPath=self.testdata_dir,
+            TestSelectors=[
+                "data_drive_zh_cn.py",
+            ],
+            FileReportPath="",
+        )
 
-if __name__ == "__main__":
-    unittest.main()
+        pipe_io = io.BytesIO()
+        collect_testcases(entry, pipe_io)
+        pipe_io.seek(0)
+
+        re = read_load_result(pipe_io)
+
+        self.assertEqual(len(re.Tests), 3)
+        self.assertEqual(len(re.LoadErrors), 0)
+
+        self.assertEqual(re.Tests[0].Name, "data_drive_zh_cn.py?test_include/[#?-#?^$%!/]")
+        self.assertEqual(re.Tests[1].Name, "data_drive_zh_cn.py?test_include/[中文-中文汉字]")
+        self.assertEqual(re.Tests[2].Name, "data_drive_zh_cn.py?test_include/[파일을 찾을 수 없습니다-ファイルが見つかりません]")


### PR DESCRIPTION
- 兼容pytest的数据驱动名称中存在unicode字符转义场景
- 执行用例时也解析用例属性
- 跳过时能正确设置错误信息
- 失败时能正确设置错误信息
- 限制错误信息长度
- 完善测试