### PR TITLE
pytest使用command来跳过-u检查

### DIFF
--- a/pytest/script/linux/run.sh
+++ b/pytest/script/linux/run.sh
@@ -12,7 +12,7 @@ echo "$TESTSOLAR_WORKSPACE"
 
 export PYTHONUNBUFFERED=1
 export TESTSOLAR_TTP_LOADINSUBPROC=1 # 隔离环境
-export PYTHONPATH="/testtools/pytest/:$PYTHONPATH"
+command export PYTHONPATH="/testtools/pytest/:$PYTHONPATH"
 
 /usr/local/bin/testtools_sdk version
 /usr/local/bin/testtools_sdk serve --tool pytest


### PR DESCRIPTION
当前run.sh中设置了`set -exu -o pipefail`，因此会导致PYTHONPATH设置失败