### PR TITLE
修复命令行传递额外参数中有空格问题

### DIFF
--- a/pytest/pyproject.toml
+++ b/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testsolar-pytestx"
-version = "0.1.26"
+version = "0.1.27"
 description = "Pytest tool for TestSolar"
 authors = [
     {name = "asiazhang2002", email = "asiazhang2002@gmail.com"},

--- a/pytest/src/testsolar_pytestx/executor.py
+++ b/pytest/src/testsolar_pytestx/executor.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from typing import BinaryIO, Optional, Dict, Any, List, Callable
 
 import pytest
+import shlex
 from loguru import logger
 from pytest import Item, Session
 
@@ -66,9 +67,7 @@ def run_testcases(
         args.append("--alluredir={}".format(allure_dir))
         initialization_allure_dir(allure_dir)
 
-    extra_args = os.environ.get("TESTSOLAR_TTP_EXTRAARGS", "")
-    if extra_args:
-        args.extend(extra_args.split())
+    append_extra_args(args)
 
     reporter: Reporter = Reporter(pipe_io=pipe_io)
 
@@ -105,6 +104,12 @@ def run_testcases(
         pytest.main(args, plugins=[my_plugin])
 
     logger.info("pytest process exit")
+
+
+def append_extra_args(args: List[str]) -> None:
+    extra_args = os.environ.get("TESTSOLAR_TTP_EXTRAARGS", "")
+    if extra_args:
+        args.extend(shlex.split(extra_args))
 
 
 class PytestExecutor:

--- a/pytest/tests/test_executor.py
+++ b/pytest/tests/test_executor.py
@@ -2,12 +2,13 @@ import io
 import unittest
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest import mock
 
 from testsolar_testtool_sdk.model.param import EntryParam
 from testsolar_testtool_sdk.model.testresult import ResultType, LogLevel
 from testsolar_testtool_sdk.pipe_reader import read_test_result
 
-from testsolar_pytestx.executor import run_testcases
+from testsolar_pytestx.executor import run_testcases, append_extra_args
 
 
 def convert_to_datetime(raw: str) -> datetime:
@@ -243,3 +244,21 @@ this is teardown
         end = read_test_result(pipe_io)
         self.assertEqual(end.ResultType, ResultType.SUCCEED)
         self.assertEqual(len(end.Steps), 3)
+
+    def test_split_args_with_space(self):
+        args = []
+
+        with mock.patch.dict(
+            "os.environ",
+            {"TESTSOLAR_TTP_EXTRAARGS": '-m "not p3" -t timeout -l "fast iu897 nuh"'},
+            clear=True,
+        ):
+            append_extra_args(args)
+
+            self.assertEqual(len(args), 6)
+            self.assertEqual(args[0], "-m")
+            self.assertEqual(args[1], "not p3")
+            self.assertEqual(args[2], "-t")
+            self.assertEqual(args[3], "timeout")
+            self.assertEqual(args[4], "-l")
+            self.assertEqual(args[5], "fast iu897 nuh")

--- a/pytest/testtool.yaml
+++ b/pytest/testtool.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0
 name: pytest
 nameZh: pytest自动化测试
 lang: python
-version: '0.1.26'
+version: '0.1.27'
 langType: INTERPRETED
 description: |-
   pytest是一个成熟的全功能Python测试工具，可以帮助您编写更好的程序。此测试工具允许您在TestSolar上运行pytest。


### PR DESCRIPTION
应该使用shlex.split而不是字符串的split