### PR TITLE
支持rerun场景用例结果上报

### DIFF
--- a/pytest/pyproject.toml
+++ b/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testsolar-pytestx"
-version = "0.1.44"
+version = "0.1.45"
 description = "Pytest tool for TestSolar"
 authors = [
     {name = "asiazhang2002", email = "asiazhang2002@gmail.com"},

--- a/pytest/src/testsolar_pytestx/case_log.py
+++ b/pytest/src/testsolar_pytestx/case_log.py
@@ -8,6 +8,10 @@ except ImportError:
 from testsolar_testtool_sdk.model.testresult import TestCaseLog, LogLevel
 
 
+def _report_failed(report: TestReport) -> bool:
+    return report.failed or report.outcome == "rerun"  # type: ignore
+
+
 def gen_logs(report: TestReport) -> TestCaseLog:
     logs: List[str] = []
     if report.capstdout:
@@ -19,7 +23,7 @@ def gen_logs(report: TestReport) -> TestCaseLog:
 
     log = "\n".join(logs)
 
-    if report.failed:
+    if _report_failed(report=report):
         error_log = report.longreprtext
         if error_log:
             log += "\n\n"
@@ -27,6 +31,6 @@ def gen_logs(report: TestReport) -> TestCaseLog:
 
     return TestCaseLog(
         Time=datetime.utcnow() - timedelta(seconds=report.duration),
-        Level=LogLevel.ERROR if report.failed else LogLevel.INFO,
+        Level=LogLevel.ERROR if _report_failed(report=report) else LogLevel.INFO,
         Content=log,
     )

--- a/pytest/testtool.yaml
+++ b/pytest/testtool.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0
 name: pytest
 nameZh: pytest自动化测试
 lang: python
-version: '0.1.44'
+version: '0.1.45'
 langType: INTERPRETED
 description: |-
   pytest是一个成熟的全功能Python测试工具，可以帮助您编写更好的程序。此测试工具允许您在TestSolar上运行pytest。

--- a/pytest/uv.lock
+++ b/pytest/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "testsolar-pytestx"
-version = "0.1.44"
+version = "0.1.45"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
若用例执行时配置了pytest-rerunfailures插件，则在执行setup失败后，插件中通过pytest hook获取的表示用例结果的report对象中failed字段不会被显式置为失败，而是会将report.outcome字段标记为rerun状态，这种情况下虽然setup执行失败，但是插件上报的结果仍然会为成功状态。因此，为兼容这种场景，插件的hook需要在report.outcome为rerun时将用例结果置为失败。