### PR TITLE
支持捕获用例异常输出

### DIFF
--- a/pytest/pyproject.toml
+++ b/pytest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testsolar-pytestx"
-version = "0.1.45"
+version = "0.1.51"
 description = "Pytest tool for TestSolar"
 authors = [
     {name = "asiazhang2002", email = "asiazhang2002@gmail.com"},

--- a/pytest/src/testsolar_pytestx/executor.py
+++ b/pytest/src/testsolar_pytestx/executor.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import BinaryIO, Optional, Dict, Any, List, Callable
 
 from loguru import logger
-from pytest import Item, Session
+from pytest import CallInfo, Item, Session
 
 try:
     from pytest import TestReport
@@ -13,7 +13,13 @@ except ImportError:
 
 from testsolar_testtool_sdk.model.param import EntryParam
 from testsolar_testtool_sdk.model.test import TestCase
-from testsolar_testtool_sdk.model.testresult import TestResult, ResultType, TestCaseStep
+from testsolar_testtool_sdk.model.testresult import (
+    TestResult,
+    ResultType,
+    TestCaseStep,
+    TestCaseLog,
+    LogLevel,
+)
 from testsolar_testtool_sdk.reporter import Reporter
 from enum import Enum
 
@@ -97,6 +103,29 @@ class PytestExecutor:
         if report.outcome == "rerun":  # type: ignore
             result_type = ResultType.FAILED
         return result_type
+
+    def pytest_runtest_makereport(self, item: Item, call: CallInfo[Any]) -> None:
+        if call.excinfo is not None:
+            logger.info(f"S {item.nodeid} log exec info")
+            testcase_name = normalize_testcase_name(item.nodeid, self.data_drive_key)
+            test_result = self.testdata[testcase_name]
+            test_result.Steps.append(
+                TestCaseStep(
+                    Title="exec failed",
+                    Logs=[
+                        TestCaseLog(
+                            Time=datetime.utcnow(),
+                            Level=LogLevel.ERROR,
+                            Content=f"{call.excinfo.typename}: {call.excinfo.value}",
+                        )
+                    ],
+                    StartTime=datetime.utcnow(),
+                    EndTime=datetime.utcnow(),
+                    ResultType=ResultType.FAILED,
+                )
+            )
+            test_result.ResultType = ResultType.FAILED
+            logger.info(f"E {item.nodeid} log exec info")
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:
         """

--- a/pytest/tests/test_executor.py
+++ b/pytest/tests/test_executor.py
@@ -143,14 +143,14 @@ this is teardown
 
         end = read_test_result(pipe_io)
         self.assertEqual(end.ResultType, ResultType.FAILED)
-        self.assertEqual(len(end.Steps), 3)
+        self.assertEqual(len(end.Steps), 4)
         self.assertIn("testdata/test_normal_case.py", end.Message)
 
-        step2 = end.Steps[1]
-        self.assertEqual(len(step2.Logs), 1)
-        self.assertEqual(step2.Logs[0].Level, LogLevel.ERROR)
-        self.assertEqual(step2.ResultType, ResultType.FAILED)
-        self.assertIn("E       assert 4 == 6", step2.Logs[0].Content)
+        step3 = end.Steps[2]
+        self.assertEqual(len(step3.Logs), 1)
+        self.assertEqual(step3.Logs[0].Level, LogLevel.ERROR)
+        self.assertEqual(step3.ResultType, ResultType.FAILED)
+        self.assertIn("E       assert 4 == 6", step3.Logs[0].Content)
 
     def test_run_failed_testcase_with_raise_error(self):
         entry = EntryParam(
@@ -171,13 +171,13 @@ this is teardown
 
         end = read_test_result(pipe_io)
         self.assertEqual(end.ResultType, ResultType.FAILED)
-        self.assertEqual(len(end.Steps), 3)
+        self.assertEqual(len(end.Steps), 4)
 
-        step2 = end.Steps[1]
-        self.assertEqual(len(step2.Logs), 1)
-        self.assertEqual(step2.Logs[0].Level, LogLevel.ERROR)
-        self.assertEqual(step2.ResultType, ResultType.FAILED)
-        self.assertIn("E       RuntimeError: this is raise runtime error", step2.Logs[0].Content)
+        step3 = end.Steps[2]
+        self.assertEqual(len(step3.Logs), 1)
+        self.assertEqual(step3.Logs[0].Level, LogLevel.ERROR)
+        self.assertEqual(step3.ResultType, ResultType.FAILED)
+        self.assertIn("E       RuntimeError: this is raise runtime error", step3.Logs[0].Content)
 
     def test_run_skipped_testcase(self):
         entry = EntryParam(
@@ -198,7 +198,7 @@ this is teardown
 
         end = read_test_result(pipe_io)
         self.assertEqual(end.ResultType, ResultType.IGNORED)
-        self.assertEqual(len(end.Steps), 2)
+        self.assertEqual(len(end.Steps), 3)
         self.assertEqual(end.Message, "Skipped: no way of currently testing this")
 
     def test_run_datadrive_with_single_value(self):

--- a/pytest/testtool.yaml
+++ b/pytest/testtool.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1.0
 name: pytest
 nameZh: pytest自动化测试
 lang: python
-version: '0.1.45'
+version: '0.1.51'
 langType: INTERPRETED
 description: |-
   pytest是一个成熟的全功能Python测试工具，可以帮助您编写更好的程序。此测试工具允许您在TestSolar上运行pytest。

--- a/pytest/uv.lock
+++ b/pytest/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.7"
 
 [[package]]
@@ -361,7 +362,7 @@ name = "portalocker"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f8/969e6f280201b40b31bcb62843c619f343dcc351dff83a5891530c9dd60e/portalocker-2.7.0.tar.gz", hash = "sha256:032e81d534a88ec1736d03f780ba073f047a06c478b06e2937486f334e955c51", size = 20183 }
 wheels = [
@@ -462,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "testsolar-pytestx"
-version = "0.1.45"
+version = "0.1.51"
 source = { virtual = "." }
 dependencies = [
     { name = "coverage" },


### PR DESCRIPTION
部分场景下用例的异常输出会被忽略，因此需要额外增加hook函数捕捉异常信息